### PR TITLE
[feature] add liveness check

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,30 +1,29 @@
+name: Build and Test
+
 on:
   pull_request:
     branches: [ develop, master ]
 
 jobs:
-  test:
-   runs-on: windows-latest
-   strategy:
-     matrix:
-       dotnet: [ '3.1', 'net461', 'net472' ]   
-   name: ${{ matrix.dotnet }} Tests
-   steps:
-   - uses: actions/checkout@v2
-   
-   - name: Setup Dotnet
-     uses: actions/setup-dotnet@v1
-     with:
-       dotnet-version: ${{ matrix.dotnet }}
-    
-   - name: Install dependencies
-     run: dotnet restore
-     working-directory: PTI.Rs232Validator.Tests
-     
-   - name: Build
-     run: dotnet build --configuration Release --no-restore
-     working-directory: PTI.Rs232Validator.Tests
-     
-   - name: Run Test
-     run: dotnet test --no-restore --verbosity normal
-     working-directory: PTI.Rs232Validator.Tests
+  Build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+    - name: Build
+      run: dotnet build src --configuration Release
+  Test:
+    needs: [Build]
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        dotnet: ['netcoreapp3.1', 'net461', 'net472']
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ matrix.dotnet }}
+      - run: PTI.Rs232Validator.Tests.csproj
+        working-directory: PTI.Rs232Validator.Tests

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -6,18 +6,28 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    name: CI on ${{ matrix.os }} - ${{ matrix.configuration }} (SDK ${{ matrix.sdk }}) 
     strategy:
       matrix:
-        dotnet: [ '3.1', 'net461', 'net472' ]
-    name: Build and Test ${{ matrix.dotnet }}
+        os: [windows-latest]
+        sdk: [ 3.1.x, net46, net47 ]     
+        configuration: [Debug, Release]
+
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
+        
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{ matrix.dotnet }}
-      - run: dotnet build --configuration Release
-        working-directory: PTI.Rs232Validator.Tests
-      - run: dotnet test
-        working-directory: PTI.Rs232Validator.Tests        
+          dotnet-version: ${{ matrix.sdk }}
+      
+      - name: Build Core
+        run: dotnet build  --configuration ${{ matrix.configuration }} PTI.Rs232Validator/PTI.Rs232Validator.csproj
+      
+      - name: Build Emulator
+        run: dotnet build  --configuration ${{ matrix.configuration }} PTI.Rs232Validator.Emulator/PTI.Rs232Validator.Emulator.csproj      
+      
+      - name: Run Tests
+        if: matrix.configuration == 'Debug'
+        run: dotnet test --no-restore --verbosity normal PTI.Rs232Validator.Tests/PTI.Rs232Validator.Tests.csproj  

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        sdk: [ 3.1.x, net46, net47 ]     
+        sdk: [ 3.1.x ]     
         configuration: [Debug, Release]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -12,7 +12,8 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
     - name: Build
-      run: dotnet build src --configuration Release
+      run: dotnet build --configuration Release
+      working-directory: PTI.Rs232Validator.Tests
   Test:
     needs: [Build]
     runs-on: windows-latest
@@ -25,5 +26,5 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet }}
-      - run: PTI.Rs232Validator.Tests.csproj
+      - run: dotnet test --no-restore
         working-directory: PTI.Rs232Validator.Tests

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -5,26 +5,19 @@ on:
     branches: [ develop, master ]
 
 jobs:
-  Build:
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-    - name: Build
-      run: dotnet build --configuration Release
-      working-directory: PTI.Rs232Validator.Tests
-  Test:
-    needs: [Build]
-    runs-on: windows-latest
+  build:
+    runs-on: windows-16.04
     strategy:
       matrix:
-        dotnet: ['netcoreapp3.1', 'net461', 'net472']
+        dotnet: [ '3.1', 'net461', 'net472' ]
+    name: Build and Test ${{ matrix.dotnet }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet }}
-      - run: dotnet test --no-restore
+      - run: dotnet build --configuration Release
         working-directory: PTI.Rs232Validator.Tests
+      - run: dotnet test
+        working-directory: PTI.Rs232Validator.Tests        

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-16.04
+    runs-on: windows-latest
     strategy:
       matrix:
         dotnet: [ '3.1', 'net461', 'net472' ]

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -6,12 +6,12 @@ on:
 
 jobs:
   build:
-    name: CI on ${{ matrix.os }} - ${{ matrix.configuration }} (SDK ${{ matrix.sdk }}) 
+    name: Build check on ${{ matrix.os }} - ${{ matrix.configuration }} (SDK ${{ matrix.sdk }}) 
     strategy:
       matrix:
         os: [windows-latest]
         sdk: [ 3.1.x ]     
-        configuration: [Debug, Release]
+        configuration: [Release, Debug]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -26,8 +26,4 @@ jobs:
         run: dotnet build  --configuration ${{ matrix.configuration }} PTI.Rs232Validator/PTI.Rs232Validator.csproj
       
       - name: Build Emulator
-        run: dotnet build  --configuration ${{ matrix.configuration }} PTI.Rs232Validator.Emulator/PTI.Rs232Validator.Emulator.csproj      
-      
-      - name: Run Tests
-        if: matrix.configuration == 'Debug'
-        run: dotnet test --no-restore --verbosity normal PTI.Rs232Validator.Tests/PTI.Rs232Validator.Tests.csproj  
+        run: dotnet build  --configuration ${{ matrix.configuration }} PTI.Rs232Validator.Emulator/PTI.Rs232Validator.Emulator.csproj

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   test:
-   runs-on: ubuntu-latest
+   runs-on: windows-latest
    strategy:
      matrix:
        dotnet: [ '3.1', 'net461', 'net472' ]   

--- a/PTI.Rs232Validator/ApexValidator.cs
+++ b/PTI.Rs232Validator/ApexValidator.cs
@@ -72,19 +72,19 @@ namespace PTI.Rs232Validator
         public override bool IsUnresponsive => _apexState.NonResponsiveCount > MaxBusyMessages;
 
         /// <inheritdoc />
-        protected override void PollDevice()
+        protected override bool PollDevice()
         {
             if (!SerialProvider.IsOpen)
             {
                 Logger?.Error("{0} Serial provider is not open", GetType().Name);
-                return;
+                return false;
             }
 
             var pollResponse = SendPollMessage();
 
             if (pollResponse is null)
             {
-                return;
+                return false;
             }
 
 
@@ -98,6 +98,8 @@ namespace PTI.Rs232Validator
 
             // Handle escrow events last so logging and other events have a logical order
             HandleEscrow(pollResponse);
+
+            return true;
         }
 
         /// <inheritdoc />

--- a/PTI.Rs232Validator/BaseValidator.cs
+++ b/PTI.Rs232Validator/BaseValidator.cs
@@ -147,7 +147,9 @@
 
             _rs232Worker.Start();
 
-            // wait for a number of valid messages from the device before we give the all clear
+            // RS-232 does not have a "ping" concept so instead we wait for a 
+            // number of healthy messages before telling the caller that the 
+            // message loop has "started successfully".
             if (_deviceIsReady.WaitOne(Config.PollingPeriod._Multiply(5)))
             {
                 Logger?.Info("{0} Polling thread started: {1}", GetType().Name, _rs232Worker.ManagedThreadId);

--- a/PTI.Rs232Validator/BaseValidator.cs
+++ b/PTI.Rs232Validator/BaseValidator.cs
@@ -15,7 +15,14 @@
         ///     Serial provider instance
         /// </summary>
         protected readonly ISerialProvider SerialProvider;
-        
+
+        /// <summary>
+        ///     Event is triggered after a number of polling
+        ///     cycles to assert that the device is operating
+        ///     normally.
+        /// </summary>
+        private readonly CounterEvent _deviceIsReady;
+
         private bool _isRunning;
         private Thread _rs232Worker;
 
@@ -32,6 +39,9 @@
             Config.Logger ??= new NullLogger();
             SerialProvider.Logger = Config.Logger;
             Logger = Config.Logger;
+
+            // Wait for this many polls before saying the acceptor is online
+            _deviceIsReady = new CounterEvent(2);
 
             Logger?.Info("{0} Created new validator: {1}", GetType().Name, config);
         }
@@ -137,9 +147,16 @@
 
             _rs232Worker.Start();
 
-            Logger?.Info("{0} Polling thread started: {1}", GetType().Name, _rs232Worker.ManagedThreadId);
+            // wait for a number of valid messages from the device before we give the all clear
+            if (_deviceIsReady.WaitOne(Config.PollingPeriod._Multiply(5)))
+            {
+                Logger?.Info("{0} Polling thread started: {1}", GetType().Name, _rs232Worker.ManagedThreadId);
 
-            return true;
+                return true;
+            }
+
+            Logger?.Info("{0} timed out waiting for a valid polling response", GetType().Name);
+            return false;
         }
 
         /// <summary>
@@ -227,13 +244,13 @@
         /// </summary>
         /// <remarks>The command will take up to <see cref="Rs232Config.PollingPeriod"/> to take effect.</remarks> 
         public abstract void ResumeAcceptance();
-        
+
         /// <summary>
         ///     Returns true if acceptance is current paused
         ///     <seealso cref="PauseAcceptance" />
         /// </summary>
         public abstract bool IsPaused { get; }
-        
+
         /// <summary>
         ///     Returns true if the API thinks the device has stopped responding
         /// </summary>
@@ -245,7 +262,7 @@
         ///     if the cash box is removed.
         /// </summary>
         public bool IsCashBoxPresent { get; protected set; }
-        
+
         /// <summary>
         ///     Main loop thread
         /// </summary>
@@ -262,7 +279,10 @@
                     }
                 }
 
-                PollDevice();
+                if (PollDevice())
+                {
+                    _deviceIsReady.Set();
+                }
 
                 Thread.Sleep(Config.PollingPeriod);
             }
@@ -272,7 +292,8 @@
         ///     Send next polling message and parse the response
         ///     This will trigger events for State, Event, and Credit messages
         /// </summary>
-        protected abstract void PollDevice();
+        /// <returns>true if polling loop transmits and receives without fault</returns>
+        protected abstract bool PollDevice();
 
         /// <summary>
         ///     Perform escrow stack function

--- a/PTI.Rs232Validator/CounterEvent.cs
+++ b/PTI.Rs232Validator/CounterEvent.cs
@@ -13,6 +13,11 @@
         private int _counter;
         private bool _executed;
 
+        /// <summary>
+        ///     Create a new counter event to signal after
+        ///     <paramref name="signalAt"/> calls to <see cref="Set"/>
+        /// </summary>
+        /// <param name="signalAt">Signal event after this many calls to Set</param>
         public CounterEvent(int signalAt)
         {
             _signalAt = signalAt;
@@ -30,7 +35,7 @@
             }
 
             ++_counter;
-            
+
             if (_counter != _signalAt)
             {
                 return;

--- a/PTI.Rs232Validator/CounterEvent.cs
+++ b/PTI.Rs232Validator/CounterEvent.cs
@@ -1,0 +1,53 @@
+﻿namespace PTI.Rs232Validator
+{
+    using System;
+    using System.Threading;
+
+    /// <summary>
+    ///     A single-use event that signals after the specified number of signals
+    /// </summary>
+    internal class CounterEvent
+    {
+        private readonly AutoResetEvent _event;
+        private readonly int _signalAt;
+        private int _counter;
+        private bool _executed;
+
+        public CounterEvent(int signalAt)
+        {
+            _signalAt = signalAt;
+            _event = new AutoResetEvent(false);
+        }
+
+        /// <summary>
+        ///     Signal the event
+        /// </summary>
+        public void Set()
+        {
+            if (_executed)
+            {
+                return;
+            }
+
+            ++_counter;
+            
+            if (_counter != _signalAt)
+            {
+                return;
+            }
+
+            _event.Set();
+            _executed = true;
+        }
+
+        /// <summary>
+        ///     Wait for event to be signalled
+        /// </summary>
+        /// <param name="timeSpan">Timeout</param>
+        /// <returns>true if event is signalled before timeout</returns>
+        public bool WaitOne(TimeSpan timeSpan)
+        {
+            return _event.WaitOne(timeSpan);
+        }
+    }
+}

--- a/PTI.Rs232Validator/Extensions.cs
+++ b/PTI.Rs232Validator/Extensions.cs
@@ -46,5 +46,26 @@ namespace PTI.Rs232Validator
         {
             return Convert.ToString(b, 2).PadLeft(8, '0');
         }
+
+        /// <summary>
+        ///     Multiple timespan by a constant value as timeSpan * factor
+        /// </summary>
+        /// <remarks>This is a backwards compatibility feature for NET Framework</remarks>
+        /// <param name="timeSpan">Time span</param>
+        /// <param name="factor">Factor</param>
+        public static TimeSpan _Multiply(this TimeSpan timeSpan, int factor)
+        {
+            if (factor <= 0)
+            {
+                throw new ArgumentException($"{nameof(factor)} must be > 0");
+            }
+            var result = timeSpan;
+            for (var i = 0; i < factor; ++i)
+            {
+                result = result.Add(timeSpan);
+            }
+
+            return result;
+        }
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -36,3 +36,8 @@ experiencing unusual behavior with your acceptor.
 Escrow mode allows the host to explicitly issue stack and return commands. This may be useful if your application 
 requires some kind of flow control between bill feeds. Use the Stack() and Return() commands to direct the acceptor 
 to perform a stack or return, respectively.
+
+## Liveness Check
+
+The RS-232 protocol does not provide a "ping" mechansim. Instead, we have a period of time in which we count a number
+of healhy poll responses. Once this is staisfied, it is assumed that the attached device is operating properly.


### PR DESCRIPTION
On startup, if the wrong port is provided or the target device
is not configured for RS232, the polling loop will continue to
run regardless of connection status. This uses a semaphore
to signal after a number of successful polling messages. Once
signalled, the acceptor's Start API will return true. Otherwise
the Start API will return false.