### PR TITLE
Increment nonresponsive count on usb removal

### DIFF
--- a/PTI.Rs232Validator/ApexValidator.cs
+++ b/PTI.Rs232Validator/ApexValidator.cs
@@ -77,6 +77,7 @@ namespace PTI.Rs232Validator
             if (!SerialProvider.IsOpen)
             {
                 Logger?.Error("{0} Serial provider is not open", GetType().Name);
+                _apexState.NonResponsiveCount++;
                 return false;
             }
 


### PR DESCRIPTION
This will prevent the mainloop from printing errors indefinitely when the usb is unplugged.